### PR TITLE
Handle semver exceptions

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,10 @@ module.exports = function(options) {
     exec(cmd, function(err, res){
       if (err) console.warn('WARN: ' + err)
       if (err || !res.length) return cb([])
-      res = res.replace(/^\s+|\s+$/g,'').split(/\n/).sort(semver.compare)
+      res = res.replace(/^\s+|\s+$/g,'').split(/\n/)
+      try{
+        res = res.sort(semver.compare)
+      } catch(e) {}
       cb(err ? [] : res)
     })
   }


### PR DESCRIPTION
When sorting tags, if any tag doesn't comply with semver, an unhandled exception occurs:

```
/tmp/git-tag-test/node_modules/semver/semver.js:273
    throw new TypeError('Invalid Version: ' + version);
          ^
TypeError: Invalid Version: 2015.03.05
    at new SemVer (/tmp/git-tag-test/node_modules/semver/semver.js:273:11)
    at SemVer.compare (/tmp/git-tag-test/node_modules/semver/semver.js:312:13)
    at compare (/tmp/git-tag-test/node_modules/semver/semver.js:535:31)
    at Array.sort (native)
    at /tmp/git-tag-test/index.js:15:48
    at ChildProcess.exithandler (child_process.js:735:7)
    at ChildProcess.emit (events.js:110:17)
    at maybeClose (child_process.js:1008:16)
    at Socket.<anonymous> (child_process.js:1176:11)
    at Socket.emit (events.js:107:17)
```

This PR just wraps the sort in a try block and ignores any exceptions.
